### PR TITLE
Migrate to actions/setup-python

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,17 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          environment-file: environment.yml
-          auto-activate-base: false
+          cache: "pip"
       - name: Dependencies
-        shell: bash -l {0}
         run: |
-          conda install pip
           if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
-      - name: Build
-        shell: bash -l {0}
+      - name: Build Jupyter Book
         run: |
           jupyter-book build . --config docs/_config.yml --toc docs/_toc.yml
       - name: Deploy


### PR DESCRIPTION
In the [current worlflow](https://github.com/worldbank/template/commit/7641d7254428bf2a4f3513b43e498a379eaaa460), the [template](https://github.com/worldbank/template) aims to encourage both (1) documentation templating and (2) reproducibility check (by executing notebooks with dependencies listed on `environment.yml`. 

While this approach may the valuable in a few simple cases; it is an anti-pattern; thus we are dropping it in favor of a simpler workflow. This PR simplifies the workflow to only execute (2). 