### PR TITLE
Upgrade Jupyter Book

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-jupyter-book==0.14
+docutils==0.17.1
+jupyter-book==0.15.1


### PR DESCRIPTION
This PR:

- Upgrades `jupyter-book==0.15.1`, including pinning `docutils==0.17.1` due to [this issue](https://sourceforge.net/p/docutils/patches/195/).
- Adds [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot). 