### PR TITLE
Updated README-building docs locally instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ To build the documentation locally, please follow these steps:
   ```shell
     pip install -e .[docs]
   ```
+  in some environments (e.g., on Mac OS), try this instead to scape the brackets:
+   ```shell
+    pip install -e .\[docs]\
+  ```
 
 - Build the documentation:
 


### PR DESCRIPTION
I added thus workaround to allow installation on Mac OS.
```shell
    pip install -e .\[docs]\
  ```